### PR TITLE
Bump version to 1.1.4 and update Vite dependencies with QR code placeholders in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,10 @@ yarn add --dev vinetqr-dev-plugin
 After installing the plugin, you need to add it to your Vite configuration file (`vite.config.js` or `vite.config.ts`).
 
 ### Example Configuration
+
 > [!NOTE]
 > Setting up options ie. smallQR, showAllNetworks, logLevel  for the plugin is optional here.
+
 
 ```javascript
 import { defineConfig } from 'vite';
@@ -84,42 +86,16 @@ When you start your development server with `vite`, you will see output similar 
 For development on VirtualBox Host-Only Network
   ➜  URL: http://192.168.56.1:5173
 
-▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
-█ ▄▄▄▄▄ █▄▄▄ ▀█▄█▄█ ▄▄▄▄▄ █
-█ █   █ ██▄▀ █ ▀███ █   █ █
-█ █▄▄▄█ ██▀▄ ▄█████ █▄▄▄█ █
-█▄▄▄▄▄▄▄█ ▀▄█ ▀▄█ █▄▄▄▄▄▄▄█
-█▄▄█ ▄▀▄▀▀▄▀█▄▀█ ▀▀▄█▀▀▀▀▄█
-█▀▀▄▄▀▄▄██▄██▄▄▄ █ ▄▄  ▀▀ █
-█▀██ ██▄ ▀▄ █▀▀▄▀▄▄▄▀▀██▀▄█
-█ ▄▀▄▄ ▄▀▀ ▄█▀▄▄▄ ▄██▀▄ ▄ █
-█▄████▄▄█ ▄  ▄▄ ▀ ▄▄▄ █▄ ██
-█ ▄▄▄▄▄ ████▀▄ ▄█ █▄█ ▄██ █
-█ █   █ █ ▀▄▄ ██▄▄▄  ▄ █▀▀█
-█ █▄▄▄█ █▀▀ ▄▀▄▀▀█▀▀▀ █   █
-█▄▄▄▄▄▄▄█▄▄█▄██▄▄▄█▄██▄██▄█
+  [QR code appears here]
 
 For development on Wi-Fi
   ➜  URL: http://192.168.1.2:5173
 
-▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
-█ ▄▄▄▄▄ █▄▀▀▄▄▄▀█▄█ ▄▄▄▄▄ █
-█ █   █ ███▄█  ▀▀▀█ █   █ █
-█ █▄▄▄█ ██▄▀▄▀ ████ █▄▄▄█ █
-█▄▄▄▄▄▄▄█ █ ▀▄▀ █▄█▄▄▄▄▄▄▄█
-█▄ ▀  ▀▄██ ▄▄▀██ ▀▀▄█▀▀▀▀▄█
-█ ▄▀ █▀▄▄▀▀  ▀█▀ █ ▄▄  ▀▀ █
-█ ▀ ▄█▀▄ █ █▄▄▀▄▀▄▄▄▀▀██▀▄█
-█ ▄█ ▀█▄▀▄ █ ▄▄█▄ ▄██▀▄ ▄ █
-█▄██▄▄▄▄█▀▀ ▀▀▄ ▀ ▄▄▄ █▄ ██
-█ ▄▄▄▄▄ ██▄▀▄▀▀██ █▄█ ▄█▀▄█
-█ █   █ █ ▀██▄██▄▄▄  ▄ █  █
-█ █▄▄▄█ █▀▄▄█▄▄ ▀█▀▀▀ █   █
-█▄▄▄▄▄▄▄█▄█▄█▄▄▄▄▄█▄██▄██▄█
+  [QR code appears here]
 
 ===============================
 
-2:23:08 PM [vite] server restarted.
+0:00:00 AM [vite] server restarted.
 
   ➜  Local:   http://localhost:5173/
   ➜  Network: http://192.168.56.1:5173/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vinetqr-dev-plugin",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "A Vite plugin to generate QR codes for network URLs during development for easy mobile access",
   "main": "index.js",
   "type": "module",
@@ -40,9 +40,9 @@
     "chalk": "^4.1.0"
   },
   "devDependencies": {
-    "vite": "^2.0.0"
+    "vite": "^6.0.7"
   },
   "peerDependencies": {
-    "vite": "^2.0.0"
+    "vite": "^6.0.0"
   }
 }


### PR DESCRIPTION
Update the version number and Vite dependencies while replacing ASCII art with QR code placeholders in the README for improved clarity.